### PR TITLE
Fix typo

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ if [ -n "$TIGRIS_URL" ]; then
 		exit 1
 	fi
 	TIGRIS_HOST=$(echo "$TIGRIS_URL" | cut -d: -f1)
-	TIGRIS_PORT=$(echo "$TIGRIS_URL" | cut -d: -f1)
+	TIGRIS_PORT=$(echo "$TIGRIS_URL" | cut -d: -f2)
 fi 
 TEST_DB="ycsb_tigris"
 RECORDCOUNT=${RECORDCOUNT:-1000000} # 1G database


### PR DESCRIPTION
Fixes a typo in TIGRIS_URL management

After fix:
```
root@dev-ycsb-7dcdc5cc7c-twv8j:/# ./run.sh
***************** properties *****************
...
"tigris.port"="8080"
...
"tigris.host"="tigris-headless"
...
**********************************************
INSERT - Takes(s): 10.0, Count: 10293, OPS: 1030.1, Avg(us): 7570, Min(us): 5860, Max(us): 18943, 99th(us): 14863, 99.9th(us): 18543, 99.99th(us): 18927
```