### PR TITLE
move cli usage to projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM ubuntu:jammy
 
 ENV GOPATH /go
 
-RUN apt update && apt install -y golang git wget \
- && wget -O - https://tigris.dev/cli-linux | tar -xz -C /usr/local/bin \
- && chmod +x /usr/local/bin/tigris
+RUN apt update && apt install -y golang git wget
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
  && chmod +x /usr/local/bin/dumb-init
@@ -28,11 +26,12 @@ FROM ubuntu:jammy
 
 COPY --from=0 /go-ycsb /go-ycsb
 COPY --from=0 /usr/local/bin/dumb-init /usr/local/bin/dumb-init
-COPY --from=0 /usr/local/bin/tigris /usr/local/bin/tigris
 
 RUN apt update && apt install -y wget && apt-get purge -y --auto-remove \
  && wget https://github.com/apple/foundationdb/releases/download/7.1.7/foundationdb-clients_7.1.7-1_amd64.deb \
  && dpkg -i foundationdb*.deb
+
+RUN wget -O - https://tigris.dev/cli-linux | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/tigris
 
 ADD workloads /workloads
 ADD run.sh /run.sh

--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,7 @@ function benchmark_tigris() {
 	then
 		echo "Tigris client has problems, will exit in 30 sec"
 		echo "Doing list databases to show you the error"
-		${CLI_PATH}tigris list databases
+		${CLI_PATH}tigris list projects
 		sleep ${FAILURE_RETRY_INTERVAL}
 		exit 1
 	fi
@@ -78,8 +78,9 @@ function benchmark_tigris() {
 	if [ "${DROPANDLOAD}" -gt 0 ]
 	then
 		echo "Dropping test database"
-		${CLI_PATH}tigris drop database $TEST_DB
+		${CLI_PATH}tigris delete-project $TEST_DB --force
 		sleep 10
+		${CLI_PATH}tigris create project $TEST_DB
 		echo "Loading new database"
 			if [ ${YCSB_LOGS_ON_STDOUT} -ne 0 ]
 			then


### PR DESCRIPTION
* Move cli usage to use projects in the wrapper script
* Download the tigris client in the actual container to avoid caching issues