### PR TITLE
separate option for duplicating the primary key and reading it

### DIFF
--- a/cmd/go-ycsb/main.go
+++ b/cmd/go-ycsb/main.go
@@ -165,7 +165,9 @@ func main() {
 	closeDone := make(chan struct{}, 1)
 
 	metrics.InitializeMetrics()
-	go metrics.ServeHTTP()
+	if os.Getenv("YCSB_METRICS_OFF") != "" {
+		go metrics.ServeHTTP()
+	}
 
 	go func() {
 		sig := <-sc

--- a/db/tigris/db.go
+++ b/db/tigris/db.go
@@ -17,15 +17,16 @@ import (
 )
 
 const (
-	tigrisDBName          = "tigris.dbname"
-	tigrisHost            = "tigris.host"
-	tigrisPort            = "tigris.port"
-	tigrisProtocol        = "tigris.protocol"
-	tigrisCollName        = "tigris.collection"
-	tigrisIndexFieldCount = "tigris.indexfieldcount"
-	tigrisIndexRead       = "tigris.indexread"
-	pkFieldName           = "Key"
-	skFieldName           = "secondaryKey"
+	tigrisDBName                 = "tigris.dbname"
+	tigrisHost                   = "tigris.host"
+	tigrisPort                   = "tigris.port"
+	tigrisProtocol               = "tigris.protocol"
+	tigrisCollName               = "tigris.collection"
+	tigrisIndexFieldCount        = "tigris.indexfieldcount"
+	tigrisDuplicatePkAsSecondary = "tigris.duplicatepk"
+	tigrisIndexRead              = "tigris.indexread"
+	pkFieldName                  = "Key"
+	skFieldName                  = "secondaryKey"
 )
 
 type tigrisDB struct {
@@ -238,6 +239,7 @@ func (c tigrisCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 	fieldCount = p.GetInt64(prop.FieldCount, prop.FieldCountDefault)
 	indexfieldCount := p.GetInt64(tigrisIndexFieldCount, 0)
 	indexRead = p.GetBool(tigrisIndexRead, false)
+	duplicatePk := p.GetBool(tigrisDuplicatePkAsSecondary, false)
 	conf := config.Driver{
 		URL:          url,
 		ClientID:     clientId,
@@ -309,7 +311,7 @@ func (c tigrisCreator) Create(p *properties.Properties) (ycsb.DB, error) {
 	// To force a read from the secondary index
 	// We create another field that is exactly the same values as "Key"
 	// But we can filter by this field when reading to use the secondary index
-	if indexRead {
+	if duplicatePk {
 		schema.Properties[skFieldName] = Field{
 			FieldType: "string",
 			Index:     true,

--- a/run.sh
+++ b/run.sh
@@ -47,6 +47,7 @@ SCANLENGTHDISTRIBUTION=${SCANLENGTHDISTRIBUTION:-uniform}
 TIGRIS_POSTFIX_TESTDB=${TIGRIS_POSTFIX_TESTDB:-0}
 TIGRIS_INDEX_FIELDCOUNT=${TIGRIS_INDEX_FIELDCOUNT:-0}
 TIGRIS_READ_INDEX=${TIGRIS_READ_INDEX:-false}
+TIGRIS_DUPLICATE_PK=${TIGRIS_DUPLICATE_PK:-false}
 
 WORKLOAD="recordcount=${RECORDCOUNT}
 operationcount=${OPERATIONCOUNT}
@@ -99,9 +100,9 @@ function benchmark_tigris() {
 		echo "Loading new database"
 			if [ ${YCSB_LOGS_ON_STDOUT} -ne 0 ]
 			then
-				${BIN_PATH}/go-ycsb load tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${LOADTHREADCOUNT}
+				${BIN_PATH}/go-ycsb load tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${LOADTHREADCOUNT}
 			else
-				${BIN_PATH}/go-ycsb load tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${LOADTHREADCOUNT} > ${YCSB_LOG_FILE}
+				${BIN_PATH}/go-ycsb load tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${LOADTHREADCOUNT} > ${YCSB_LOG_FILE}
 			fi
 	fi
 
@@ -112,9 +113,9 @@ function benchmark_tigris() {
 			echo "Running benchmark"
 				if [ ${YCSB_LOGS_ON_STDOUT} -ne 0 ]
 				then
-					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${RUNTHREADCOUNT}
+					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${RUNTHREADCOUNT}
 				else
-					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${RUNTHREADCOUNT} > ${YCSB_LOG_FILE}
+					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${RUNTHREADCOUNT} > ${YCSB_LOG_FILE}
 				fi
 			echo "Run completed, sleeping before running again"
 			sleep ${RUNTHREADSLEEPINTERVAL}
@@ -128,9 +129,9 @@ function benchmark_tigris() {
 				echo "Running benchmark for ${th} thread(s)"
 				if [ ${YCSB_LOGS_ON_STDOUT} -ne 0 ]
 				then
-					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${th}
+					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${th}
 				else
-					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexread="${TIGRIS_READ_INDEX}" -P workloads/dynamic -p threadcount=${th} > ${YCSB_LOG_FILE}
+					timeout ${RUNTHREADDURATION} ${BIN_PATH}/go-ycsb run tigris -p tigris.host="$TIGRIS_HOST" -p tigris.port="$TIGRIS_PORT" -p tigris.dbname="$TEST_DB" -p fieldcount="${FIELDCOUNT}" -p tigris.indexfieldcount="${TIGRIS_INDEX_FIELDCOUNT}" -p fieldlength=${FIELDLENGTH} -p tigris.indexread="${TIGRIS_READ_INDEX}" -p tigris.duplicatepk="${TIGRIS_DUPLICATE_PK}" -P workloads/dynamic -p threadcount=${th} > ${YCSB_LOG_FILE}
 				fi
 				sleep ${RUNTHREADSLEEPINTERVAL}
 			done


### PR DESCRIPTION
Separate options for duplicating the primary key as a secondary index and reading from it. 
Added environment variable to control metrics (possible to run a ycsb without emitting metrics). 